### PR TITLE
Add InfoAPI

### DIFF
--- a/src/apis/info/api.ts
+++ b/src/apis/info/api.ts
@@ -1,0 +1,193 @@
+/**
+ * @packageDocumentation
+ * @module InfoAPI
+ */
+import AvalancheCore from '../../avalanche';
+import {JRPCAPI, RequestResponseData} from "../../utils/types"
+
+/**
+ * Class for interacting with a node's InfoAPI.
+ * 
+ * @category RPCAPIs
+ * 
+ * @remarks This extends the [[JRPCAPI]] class. This class should not be directly called. Instead, use the [[Avalanche.addAPI]] function to register this interface with Avalanche.
+ */ 
+export class InfoAPI extends JRPCAPI{
+
+    /**
+     * Fetches the nodeID from the node.
+     * 
+     * @returns Returns a Promise<string> of the nodeID.
+     */
+    getNodeID = async ():Promise<string> => {
+        let params = {};
+        return this.callMethod("info.getNodeID", params).then((response:RequestResponseData) => {
+            return response.data["result"]["nodeID"];
+        });
+    }
+
+    /**
+     * Fetches the networkID from the node.
+     * 
+     * @returns Returns a Promise<number> of the networkID.
+     */
+    getNetworkID = async ():Promise<number> => {
+        let params = {};
+        return this.callMethod("info.getNetworkID", params).then((response:RequestResponseData) => {
+            return response.data["result"]["networkID"];
+        });
+    }
+
+    /**
+     * Assign an API an alias, a different endpoint for the API. The original endpoint will still work. This change only affects this node; other nodes will not know about this alias.
+     * 
+     * @param endpoint The original endpoint of the API. endpoint should only include the part of the endpoint after /ext/
+     * @param alias The API being aliased can now be called at ext/alias
+     * 
+     * @returns Returns a Promise<boolean> containing success, true for success, false for failure.
+     */
+    alias = async (endpoint:string, alias:string):Promise<boolean> => {
+        let params = {
+            "endpoint": endpoint,
+            "alias":alias
+        };
+        return this.callMethod("info.alias", params).then((response:RequestResponseData) => {
+            return response.data["result"]["success"];
+        });
+    }
+
+    /**
+     * Give a blockchain an alias, a different name that can be used any place the blockchain’s ID is used.
+     * 
+     * @param endpoint The blockchain’s ID
+     * @param alias Can now be used in place of the blockchain’s ID (in API endpoints, for example)
+     * 
+     * @returns Returns a Promise<boolean> containing success, true for success, false for failure.
+     */
+    aliasChain = async (chain:string, alias:string):Promise<boolean> => {
+        let params = {
+            "chain": chain,
+            "alias":alias
+        };
+        return this.callMethod("info.aliasChain", params).then((response:RequestResponseData) => {
+            return response.data["result"]["success"];
+        });
+    }
+
+    /**
+     * Fetches the blockchainID from the node for a given alias.
+     * 
+     * @param alias The blockchain alias to get the blockchainID
+     * 
+     * @returns Returns a Promise<string> containing the base 58 string representation of the blockchainID.
+     */
+    getBlockchainID = async (alias:string):Promise<string> => {
+        let params = {
+            "alias":alias
+        };
+        return this.callMethod("info.getBlockchainID", params).then((response:RequestResponseData) => {
+            return response.data["result"]["blockchainID"];
+        });
+    }
+
+    /**
+     * Fetches the version of Gecko this node is running
+     *
+     * @returns Returns a Promise<string> containing the version of Gecko.
+     */
+    getNodeVersion = async ():Promise<string> => {
+        return this.callMethod("info.getNodeVersion").then((response:RequestResponseData) => {
+            return response.data["result"]["version"];
+        });
+    }
+
+    /**
+     * Fetches the network name this node is running on
+     *
+     * @returns Returns a Promise<string> containing the network name.
+     */
+    getNetworkName = async ():Promise<string> => {
+        return this.callMethod("info.getNetworkName").then((response:RequestResponseData) => {
+            return response.data["result"]["networkName"];
+        });
+    }
+
+    /**
+     * Dump the mutex statistics of the node to the specified file.
+     * 
+     * @param filename Name of the file to write the statistics.
+     * 
+     * @returns Promise for a boolean that is true on success.
+     */
+    lockProfile = async (filename:string):Promise<boolean> => {
+        let params = {
+            "fileName": filename
+        };
+        return this.callMethod("info.lockProfile", params).then((response:RequestResponseData) => {
+            return response.data["result"]["success"];
+        });
+    }
+
+    /**
+     * Dump the current memory footprint of the node to the specified file.
+     * 
+     * @param filename Name of the file to write the profile information.
+     * 
+     * @returns Promise for a boolean that is true on success.
+     */
+    memoryProfile = async (filename:string):Promise<boolean> => {
+        let params = {
+            "fileName": filename
+        };
+        return this.callMethod("info.memoryProfile", params).then((response:RequestResponseData) => {
+            return response.data["result"]["success"];
+        });
+    }
+
+    /**
+     * Returns the peers connected to the node.
+     * 
+     * @returns Promise for the list of connected peers in <ip>:<port> format.
+     */
+    peers = async ():Promise<Array<string>> => {
+        return this.callMethod("info.peers").then((response:RequestResponseData) => {
+            return response.data["result"]["peers"];
+        });
+    }
+    /**
+     * Start profiling the cpu utilization of the node. Will dump the profile information into the specified file on stop.
+     * 
+     * @param filename Name of the file to write the profile information on stop.
+     * 
+     * @returns Promise for a boolean that is true on success.
+     */
+    startCPUProfiler = async (filename:string):Promise<boolean> => {
+        let params = {
+            "fileName": filename
+        };
+        return this.callMethod("info.startCPUProfiler", params).then((response:RequestResponseData) => {
+            return response.data["result"]["success"];
+        });
+    }
+
+    /**
+     * Stop the CPU profile that was previously started.
+     * 
+     * @returns Promise for a boolean that is true on success.
+     */
+    stopCPUProfiler = async ():Promise<boolean> => {
+        return this.callMethod("info.stopCPUProfiler").then((response:RequestResponseData) => {
+            return response.data["result"]["success"];
+        });
+    }
+
+    /**
+     * This class should not be instantiated directly. Instead use the [[Avalanche.addAPI]] method.
+     * 
+     * @param core A reference to the Avalanche class
+     * @param baseurl Defaults to the string "/ext/info" as the path to rpc's baseurl
+     */
+    constructor(core:AvalancheCore, baseurl:string = "/ext/info"){ super(core, baseurl); }
+}
+
+export default InfoAPI;

--- a/src/apis/info/api.ts
+++ b/src/apis/info/api.ts
@@ -15,66 +15,6 @@ import {JRPCAPI, RequestResponseData} from "../../utils/types"
 export class InfoAPI extends JRPCAPI{
 
     /**
-     * Fetches the nodeID from the node.
-     * 
-     * @returns Returns a Promise<string> of the nodeID.
-     */
-    getNodeID = async ():Promise<string> => {
-        let params = {};
-        return this.callMethod("info.getNodeID", params).then((response:RequestResponseData) => {
-            return response.data["result"]["nodeID"];
-        });
-    }
-
-    /**
-     * Fetches the networkID from the node.
-     * 
-     * @returns Returns a Promise<number> of the networkID.
-     */
-    getNetworkID = async ():Promise<number> => {
-        let params = {};
-        return this.callMethod("info.getNetworkID", params).then((response:RequestResponseData) => {
-            return response.data["result"]["networkID"];
-        });
-    }
-
-    /**
-     * Assign an API an alias, a different endpoint for the API. The original endpoint will still work. This change only affects this node; other nodes will not know about this alias.
-     * 
-     * @param endpoint The original endpoint of the API. endpoint should only include the part of the endpoint after /ext/
-     * @param alias The API being aliased can now be called at ext/alias
-     * 
-     * @returns Returns a Promise<boolean> containing success, true for success, false for failure.
-     */
-    alias = async (endpoint:string, alias:string):Promise<boolean> => {
-        let params = {
-            "endpoint": endpoint,
-            "alias":alias
-        };
-        return this.callMethod("info.alias", params).then((response:RequestResponseData) => {
-            return response.data["result"]["success"];
-        });
-    }
-
-    /**
-     * Give a blockchain an alias, a different name that can be used any place the blockchain’s ID is used.
-     * 
-     * @param endpoint The blockchain’s ID
-     * @param alias Can now be used in place of the blockchain’s ID (in API endpoints, for example)
-     * 
-     * @returns Returns a Promise<boolean> containing success, true for success, false for failure.
-     */
-    aliasChain = async (chain:string, alias:string):Promise<boolean> => {
-        let params = {
-            "chain": chain,
-            "alias":alias
-        };
-        return this.callMethod("info.aliasChain", params).then((response:RequestResponseData) => {
-            return response.data["result"]["success"];
-        });
-    }
-
-    /**
      * Fetches the blockchainID from the node for a given alias.
      * 
      * @param alias The blockchain alias to get the blockchainID
@@ -91,13 +31,14 @@ export class InfoAPI extends JRPCAPI{
     }
 
     /**
-     * Fetches the version of Gecko this node is running
-     *
-     * @returns Returns a Promise<string> containing the version of Gecko.
+     * Fetches the networkID from the node.
+     * 
+     * @returns Returns a Promise<number> of the networkID.
      */
-    getNodeVersion = async ():Promise<string> => {
-        return this.callMethod("info.getNodeVersion").then((response:RequestResponseData) => {
-            return response.data["result"]["version"];
+    getNetworkID = async ():Promise<number> => {
+        let params = {};
+        return this.callMethod("info.getNetworkID", params).then((response:RequestResponseData) => {
+            return response.data["result"]["networkID"];
         });
     }
 
@@ -113,34 +54,25 @@ export class InfoAPI extends JRPCAPI{
     }
 
     /**
-     * Dump the mutex statistics of the node to the specified file.
+     * Fetches the nodeID from the node.
      * 
-     * @param filename Name of the file to write the statistics.
-     * 
-     * @returns Promise for a boolean that is true on success.
+     * @returns Returns a Promise<string> of the nodeID.
      */
-    lockProfile = async (filename:string):Promise<boolean> => {
-        let params = {
-            "fileName": filename
-        };
-        return this.callMethod("info.lockProfile", params).then((response:RequestResponseData) => {
-            return response.data["result"]["success"];
+    getNodeID = async ():Promise<string> => {
+        let params = {};
+        return this.callMethod("info.getNodeID", params).then((response:RequestResponseData) => {
+            return response.data["result"]["nodeID"];
         });
     }
 
     /**
-     * Dump the current memory footprint of the node to the specified file.
-     * 
-     * @param filename Name of the file to write the profile information.
-     * 
-     * @returns Promise for a boolean that is true on success.
+     * Fetches the version of Gecko this node is running
+     *
+     * @returns Returns a Promise<string> containing the version of Gecko.
      */
-    memoryProfile = async (filename:string):Promise<boolean> => {
-        let params = {
-            "fileName": filename
-        };
-        return this.callMethod("info.memoryProfile", params).then((response:RequestResponseData) => {
-            return response.data["result"]["success"];
+    getNodeVersion = async ():Promise<string> => {
+        return this.callMethod("info.getNodeVersion").then((response:RequestResponseData) => {
+            return response.data["result"]["version"];
         });
     }
 
@@ -154,39 +86,6 @@ export class InfoAPI extends JRPCAPI{
             return response.data["result"]["peers"];
         });
     }
-    /**
-     * Start profiling the cpu utilization of the node. Will dump the profile information into the specified file on stop.
-     * 
-     * @param filename Name of the file to write the profile information on stop.
-     * 
-     * @returns Promise for a boolean that is true on success.
-     */
-    startCPUProfiler = async (filename:string):Promise<boolean> => {
-        let params = {
-            "fileName": filename
-        };
-        return this.callMethod("info.startCPUProfiler", params).then((response:RequestResponseData) => {
-            return response.data["result"]["success"];
-        });
-    }
-
-    /**
-     * Stop the CPU profile that was previously started.
-     * 
-     * @returns Promise for a boolean that is true on success.
-     */
-    stopCPUProfiler = async ():Promise<boolean> => {
-        return this.callMethod("info.stopCPUProfiler").then((response:RequestResponseData) => {
-            return response.data["result"]["success"];
-        });
-    }
-
-    /**
-     * This class should not be instantiated directly. Instead use the [[Avalanche.addAPI]] method.
-     * 
-     * @param core A reference to the Avalanche class
-     * @param baseurl Defaults to the string "/ext/info" as the path to rpc's baseurl
-     */
     constructor(core:AvalancheCore, baseurl:string = "/ext/info"){ super(core, baseurl); }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import BinTools from './utils/bintools';
 import DB from './utils/db';
 import { Defaults } from './utils/types';
 import HealthAPI from "./apis/health/api";
+import InfoAPI from "./apis/info/api"
 
 /**
  * Avalanche.js is middleware for interacting with AVA node RPC APIs. 
@@ -39,10 +40,17 @@ export class Avalanche extends AvalancheCore {
     }
 
     /**
-     * Returns a reference to the Platform RPC.
+     * Returns a reference to the Health RPC for a node.
      */
-    Platform = () => {
-        return this.apis["platform"] as PlatformAPI;
+    Health = () => {
+        return this.apis["health"] as HealthAPI;
+    }
+
+    /**
+     * Returns a reference to the Info RPC for a node.
+     */
+    Info = () => {
+        return this.apis["info"] as HealthAPI;
     }
 
     /**
@@ -53,10 +61,10 @@ export class Avalanche extends AvalancheCore {
     }
 
     /**
-     * Returns a reference to the Health RPC for a node.
+     * Returns a reference to the Platform RPC.
      */
-    Health = () => {
-        return this.apis["health"] as HealthAPI;
+    Platform = () => {
+        return this.apis["platform"] as PlatformAPI;
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export class Avalanche extends AvalancheCore {
      * Returns a reference to the Info RPC for a node.
      */
     Info = () => {
-        return this.apis["info"] as HealthAPI;
+        return this.apis["info"] as InfoAPI;
     }
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,9 +93,10 @@ export class Avalanche extends AvalancheCore {
         if(!skipinit){
             this.addAPI("admin", AdminAPI);
             this.addAPI("avm", AVMAPI, "/ext/bc/X", chainid);
-            this.addAPI("platform", PlatformAPI);
-            this.addAPI("keystore", KeystoreAPI);
             this.addAPI('health', HealthAPI);
+            this.addAPI('info', InfoAPI);
+            this.addAPI("keystore", KeystoreAPI);
+            this.addAPI("platform", PlatformAPI);
         }
     }
 }

--- a/tests/apis/info/api.test.ts
+++ b/tests/apis/info/api.test.ts
@@ -1,0 +1,128 @@
+import mockAxios from 'jest-mock-axios';
+import { Avalanche } from "src";
+import InfoAPI from "src/apis/info/api";
+describe("Info", () => {
+    const ip:string = '127.0.0.1';
+    const port:number = 9650;
+    const protocol:string = "https";
+
+    let avalanche:Avalanche = new Avalanche(ip,port,protocol, 12345, "What is my purpose? You pass butter. Oh my god.", false);
+    let info:InfoAPI;
+
+    beforeAll(() => {
+        info = avalanche.Info();
+    });
+
+    afterEach(() => {
+        mockAxios.reset();
+    });
+
+    test("getBlockchainID", async ()=>{
+        let result:Promise<string> = info.getBlockchainID('avm');
+        let payload:object = {
+            "result": {
+                "blockchainID": avalanche.AVM().getBlockchainID()
+            }
+        };
+        let responseObj = {
+            data: payload
+        };
+
+        mockAxios.mockResponse(responseObj);
+        let response:string = await result;
+
+        expect(mockAxios.request).toHaveBeenCalledTimes(1);
+        expect(response).toBe("What is my purpose? You pass butter. Oh my god.");
+    });
+
+    test("getNetworkID", async ()=>{
+        let result:Promise<number> = info.getNetworkID();
+        let payload:object = {
+            "result": {
+                "networkID": 12345
+            }
+        };
+        let responseObj = {
+            data: payload
+        };
+
+        mockAxios.mockResponse(responseObj);
+        let response:number = await result;
+
+        expect(mockAxios.request).toHaveBeenCalledTimes(1);
+        expect(response).toBe(12345);
+    });
+
+    test("getNetworkName", async ()=>{
+        let result:Promise<string> = info.getNetworkName();
+        let payload:object = {
+            "result": {
+                "networkName": "denali"
+            }
+        };
+        let responseObj = {
+            data: payload
+        };
+
+        mockAxios.mockResponse(responseObj);
+        let response:string = await result;
+
+        expect(mockAxios.request).toHaveBeenCalledTimes(1);
+        expect(response).toBe("denali");
+    });
+
+    test("getNodeID", async ()=>{
+        let result:Promise<string> = info.getNodeID();
+        let payload:object = {
+            "result": {
+                "nodeID": "abcd"
+            }
+        };
+        let responseObj = {
+            data: payload
+        };
+
+        mockAxios.mockResponse(responseObj);
+        let response:string = await result;
+
+        expect(mockAxios.request).toHaveBeenCalledTimes(1);
+        expect(response).toBe("abcd");
+    });
+
+    test("getNodeVersion", async ()=>{
+        let result:Promise<string> = info.getNodeVersion();
+        let payload:object = {
+            "result": {
+                "version": "avalanche/0.5.5"
+            }
+        };
+        let responseObj = {
+            data: payload
+        };
+
+        mockAxios.mockResponse(responseObj);
+        let response:string = await result;
+
+        expect(mockAxios.request).toHaveBeenCalledTimes(1);
+        expect(response).toBe("avalanche/0.5.5");
+    });
+
+    test("peers", async ()=>{
+        let peers = ['p1', 'p2'];
+        let result:Promise<Array<string>> = info.peers();
+        let payload:object = {
+            "result": {
+                "peers": peers
+            }
+        };
+        let responseObj = {
+            data: payload
+        };
+
+        mockAxios.mockResponse(responseObj);
+        let response:Array<string> = await result;
+
+        expect(mockAxios.request).toHaveBeenCalledTimes(1);
+        expect(response).toBe(peers);
+    });
+});


### PR DESCRIPTION
In [Gecko 0.5.7](https://github.com/ava-labs/gecko/releases/tag/v0.5.7) public admin API RPCs are now duplicated to the [info endpoint](https://docs.avax.network/v1.0/en/api/info). These duplicated calls are deprecated on the admin API. Once network services (wallet + faucet + explorer) are moved to the info API they'll be removed.

This PR adds these endpoints and tests:

* `info.getBlockchainID`
* `info.getNetworkID`
* `info.getNetworkName`
* `info.getNodeID`
* `info.getNodeVersion`
* `info.peers`

Leaving the matching admin endpoints and tests until they're removed from Gecko.

