### PR TITLE
fix: BN toString in params for `exportAVA`

### DIFF
--- a/src/apis/avm/api.ts
+++ b/src/apis/avm/api.ts
@@ -427,7 +427,7 @@ class AVMAPI extends JRPCAPI{
     exportAVA = async (username: string, password:string, to:string, amount:BN):Promise<string> => {
         let params = {
             "to": to,
-            "amount": amount,
+            "amount": amount.toString(10),
             "username": username,
             "password": password
         }

--- a/src/apis/platform/api.ts
+++ b/src/apis/platform/api.ts
@@ -356,7 +356,7 @@ class PlatformAPI extends JRPCAPI{
     exportAVA = async (amount:BN, to:string,payerNonce:number):Promise<string> => {
         let params = {
             "to": to,
-            "amount": amount,
+            "amount": amount.toString(10),
             "payerNonce": payerNonce
         }
         return this.callMethod("platform.exportAVA", params).then((response:RequestResponseData) => {


### PR DESCRIPTION
Transform BN to a string in params for exportAVA function in `platform` and `avm` API .


Should fix #45 