### PR TITLE
Updates to bech32-upgrade

### DIFF
--- a/src/apis/platformvm/keychain.ts
+++ b/src/apis/platformvm/keychain.ts
@@ -38,7 +38,7 @@ const bintools: BinTools = BinTools.getInstance();
 /**
  * Class for representing a private and public keypair on the Platform Chain. 
  */
-export class PlatformKeyPair extends KeyPair {
+export class PlatformVMKeyPair extends KeyPair {
     protected keypair:elliptic.ec.KeyPair
     protected entropy:Buffer;
 
@@ -202,9 +202,9 @@ export class PlatformKeyPair extends KeyPair {
 /**
  * Class for representing a key chain in Avalanche. 
  * 
- * @typeparam PlatformKeyPair Class extending [[KeyPair]] which is used as the key in [[PlatformKeyChain]]
+ * @typeparam PlatformVMKeyPair Class extending [[KeyPair]] which is used as the key in [[PlatformVMKeyChain]]
  */
-export class PlatformKeyChain extends KeyChain<PlatformKeyPair> {
+export class PlatformVMKeyChain extends KeyChain<PlatformVMKeyPair> {
 
     /**
      * Makes a new key pair, returns the address.
@@ -214,7 +214,7 @@ export class PlatformKeyChain extends KeyChain<PlatformKeyPair> {
      * @returns Address of the new key pair
      */
     makeKey = (entropy:Buffer = undefined):Buffer => {
-        let keypair:PlatformKeyPair = new PlatformKeyPair(this.hrp, this.chainid, entropy);
+        let keypair:PlatformVMKeyPair = new PlatformVMKeyPair(this.hrp, this.chainid, entropy);
         this.addKey(keypair);
         return keypair.getAddress();
     }
@@ -227,7 +227,7 @@ export class PlatformKeyChain extends KeyChain<PlatformKeyPair> {
      * @returns Address of the new key pair
      */
     importKey = (privk:Buffer | string):Buffer => {
-        let keypair:PlatformKeyPair = new PlatformKeyPair(this.hrp, this.chainid);
+        let keypair:PlatformVMKeyPair = new PlatformVMKeyPair(this.hrp, this.chainid);
         let pk:Buffer;
         if(typeof privk === 'string'){
             pk = bintools.cb58Decode(privk.split('-')[1]);
@@ -242,7 +242,7 @@ export class PlatformKeyChain extends KeyChain<PlatformKeyPair> {
     }
 
     /**
-     * Returns instance of PlatformKeyChain.
+     * Returns instance of PlatformVMKeyChain.
      */
     constructor(hrp:string, chainid:string){
         super(hrp, chainid);

--- a/src/apis/platformvm/types.ts
+++ b/src/apis/platformvm/types.ts
@@ -4,13 +4,6 @@
  */
 
 import BN from 'bn.js';
-import BinTools from '../../utils/bintools';
-
-
-/**
- * @ignore
- */
-const bintools:BinTools = BinTools.getInstance();
 
 export class PlatformVMConstants {
   static ONEAVAX:BN = new BN(1000000000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,8 @@ export {BaseTx, CreateAssetTx, OperationTx, UnsignedTx, Tx} from './apis/avm/tx'
 export {SigIdx, Signature, Address, UTXOID, InitialStates, AVMConstants, MergeRule, UnixNow} from './apis/avm/types';
 export {UTXO, UTXOSet} from './apis/avm/utxos';	
 
-export { PlatformKeyPair, PlatformKeyChain } from './apis/platformvm/keychain';
+export { PlatformVMKeyPair, PlatformVMKeyChain } from './apis/platformvm/keychain';
+export { PlatformVMConstants } from './apis/platformvm/types';
 
 export { AdminAPI as Admin };
 export { AVMAPI as AVM };

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,9 +57,9 @@ export default class Avalanche extends AvalancheCore {
   NodeKeys = () => this.apis.keystore as KeystoreAPI;
 
   /**
-     * Returns a reference to the Platform RPC.
+     * Returns a reference to the PlatformVM RPC.
      */
-  Platform = () => this.apis.platform as PlatformVMAPI;
+  PlatformVM = () => this.apis.platform as PlatformVMAPI;
 
   /**
      * Creates a new Avalanche instance. Sets the address and port of the main Avalanche Client.

--- a/tests/apis/avm/keychain.test.ts
+++ b/tests/apis/avm/keychain.test.ts
@@ -1,5 +1,5 @@
 import { AVMKeyChain, AVMKeyPair } from 'src/apis/avm/keychain';
-import { Avalanche } from './../../../src/index'
+import { Avalanche } from 'src/index'
 import { Buffer } from 'buffer/';
 import createHash from 'create-hash';
 import BinTools from 'src/utils/bintools';
@@ -17,43 +17,43 @@ describe('AVMKeyPair', () => {
 
   test('human readable part', () => {
     let hrp:string = avalanche.getHRP();
-    let networkID:number = avalanche.getNetworkID()
+    let networkID:number = avalanche.getNetworkID();
     expect(hrp).toBe("local");
     expect(networkID).toBe(12345);
 
     avalanche.setNetworkID(2);
     hrp = avalanche.getHRP();
-    networkID = avalanche.getNetworkID()
+    networkID = avalanche.getNetworkID();
     expect(hrp).toBe("cascade");
     expect(networkID).toBe(2);
 
     avalanche.setNetworkID(3);
     hrp = avalanche.getHRP();
-    networkID = avalanche.getNetworkID()
+    networkID = avalanche.getNetworkID();
     expect(hrp).toBe("denali");
     expect(networkID).toBe(3);
 
     avalanche.setNetworkID(4);
     hrp = avalanche.getHRP();
-    networkID = avalanche.getNetworkID()
+    networkID = avalanche.getNetworkID();
     expect(hrp).toBe("everest");
     expect(networkID).toBe(4);
 
     avalanche.setNetworkID(0);
     hrp = avalanche.getHRP();
-    networkID = avalanche.getNetworkID()
+    networkID = avalanche.getNetworkID();
     expect(hrp).toBe("custom");
     expect(networkID).toBe(0);
 
     avalanche.setNetworkID(1);
     hrp = avalanche.getHRP();
-    networkID = avalanche.getNetworkID()
+    networkID = avalanche.getNetworkID();
     expect(hrp).toBe("avax");
     expect(networkID).toBe(1);
 
     avalanche.setNetworkID(12345);
     hrp = avalanche.getHRP();
-    networkID = avalanche.getNetworkID()
+    networkID = avalanche.getNetworkID();
     expect(hrp).toBe("local");
     expect(networkID).toBe(12345);
   });

--- a/tests/apis/avm/keychain.test.ts
+++ b/tests/apis/avm/keychain.test.ts
@@ -1,4 +1,5 @@
 import { AVMKeyChain, AVMKeyPair } from 'src/apis/avm/keychain';
+import { Avalanche } from './../../../src/index'
 import { Buffer } from 'buffer/';
 import createHash from 'create-hash';
 import BinTools from 'src/utils/bintools';
@@ -6,7 +7,57 @@ import BinTools from 'src/utils/bintools';
 const bintools = BinTools.getInstance();
 const alias = 'X';
 const hrp = "tests"
+
 describe('AVMKeyPair', () => {
+  const networkid:number = 12345;
+  const ip:string = '127.0.0.1';
+  const port:number = 9650;
+  const protocol:string = 'https';
+  const avalanche:Avalanche = new Avalanche(ip, port, protocol, networkid, undefined, undefined, true);
+
+  test('human readable part', () => {
+    let hrp:string = avalanche.getHRP();
+    let networkID:number = avalanche.getNetworkID()
+    expect(hrp).toBe("local");
+    expect(networkID).toBe(12345);
+
+    avalanche.setNetworkID(2);
+    hrp = avalanche.getHRP();
+    networkID = avalanche.getNetworkID()
+    expect(hrp).toBe("cascade");
+    expect(networkID).toBe(2);
+
+    avalanche.setNetworkID(3);
+    hrp = avalanche.getHRP();
+    networkID = avalanche.getNetworkID()
+    expect(hrp).toBe("denali");
+    expect(networkID).toBe(3);
+
+    avalanche.setNetworkID(4);
+    hrp = avalanche.getHRP();
+    networkID = avalanche.getNetworkID()
+    expect(hrp).toBe("everest");
+    expect(networkID).toBe(4);
+
+    avalanche.setNetworkID(0);
+    hrp = avalanche.getHRP();
+    networkID = avalanche.getNetworkID()
+    expect(hrp).toBe("custom");
+    expect(networkID).toBe(0);
+
+    avalanche.setNetworkID(1);
+    hrp = avalanche.getHRP();
+    networkID = avalanche.getNetworkID()
+    expect(hrp).toBe("avax");
+    expect(networkID).toBe(1);
+
+    avalanche.setNetworkID(12345);
+    hrp = avalanche.getHRP();
+    networkID = avalanche.getNetworkID()
+    expect(hrp).toBe("local");
+    expect(networkID).toBe(12345);
+  });
+
   test('repeatable 1', () => {
     const kp:AVMKeyPair = new AVMKeyPair(hrp, alias);
     kp.importKey(Buffer.from('ef9bf2d4436491c153967c9709dd8e82795bdb9b5ad44ee22c2903005d1cf676', 'hex'));

--- a/tests/apis/platformvm/keychain.test.ts
+++ b/tests/apis/platformvm/keychain.test.ts
@@ -1,4 +1,5 @@
-import { PlatformKeyChain, PlatformKeyPair } from 'src/apis/platformvm/keychain';
+import { PlatformVMKeyChain, PlatformVMKeyPair } from 'src/apis/platformvm/keychain';
+import { Avalanche } from './../../../src/index'
 import { Buffer } from 'buffer/';
 import createHash from 'create-hash';
 import BinTools from 'src/utils/bintools';
@@ -6,9 +7,58 @@ import BinTools from 'src/utils/bintools';
 const bintools = BinTools.getInstance();
 const alias = 'P';
 const hrp = "tests";
-describe('PlatformKeyPair', () => {
+describe('PlatformVMKeyPair', () => {
+  const networkid:number = 12345;
+  const ip:string = '127.0.0.1';
+  const port:number = 9650;
+  const protocol:string = 'https';
+  const avalanche:Avalanche = new Avalanche(ip, port, protocol, networkid, undefined, undefined, true);
+
+  test('human readable part', () => {
+    let hrp:string = avalanche.getHRP();
+    let networkID:number = avalanche.getNetworkID()
+    expect(hrp).toBe("local");
+    expect(networkID).toBe(12345);
+
+    avalanche.setNetworkID(2);
+    hrp = avalanche.getHRP();
+    networkID = avalanche.getNetworkID()
+    expect(hrp).toBe("cascade");
+    expect(networkID).toBe(2);
+
+    avalanche.setNetworkID(3);
+    hrp = avalanche.getHRP();
+    networkID = avalanche.getNetworkID()
+    expect(hrp).toBe("denali");
+    expect(networkID).toBe(3);
+
+    avalanche.setNetworkID(4);
+    hrp = avalanche.getHRP();
+    networkID = avalanche.getNetworkID()
+    expect(hrp).toBe("everest");
+    expect(networkID).toBe(4);
+
+    avalanche.setNetworkID(0);
+    hrp = avalanche.getHRP();
+    networkID = avalanche.getNetworkID()
+    expect(hrp).toBe("custom");
+    expect(networkID).toBe(0);
+
+    avalanche.setNetworkID(1);
+    hrp = avalanche.getHRP();
+    networkID = avalanche.getNetworkID()
+    expect(hrp).toBe("avax");
+    expect(networkID).toBe(1);
+
+    avalanche.setNetworkID(12345);
+    hrp = avalanche.getHRP();
+    networkID = avalanche.getNetworkID()
+    expect(hrp).toBe("local");
+    expect(networkID).toBe(12345);
+  });
+
   test('repeatable 1', () => {
-    const kp:PlatformKeyPair = new PlatformKeyPair(hrp, alias);
+    const kp:PlatformVMKeyPair = new PlatformVMKeyPair(hrp, alias);
     kp.importKey(Buffer.from('ef9bf2d4436491c153967c9709dd8e82795bdb9b5ad44ee22c2903005d1cf676', 'hex'));
     expect(kp.getPublicKey().toString('hex')).toBe('033fad3644deb20d7a210d12757092312451c112d04773cee2699fbb59dc8bb2ef');
 
@@ -21,7 +71,7 @@ describe('PlatformKeyPair', () => {
   });
 
   test('repeatable 2', () => {
-    const kp:PlatformKeyPair = new PlatformKeyPair(hrp, alias);
+    const kp:PlatformVMKeyPair = new PlatformVMKeyPair(hrp, alias);
     kp.importKey(Buffer.from('17c692d4a99d12f629d9f0ff92ec0dba15c9a83e85487b085c1a3018286995c6', 'hex'));
     expect(kp.getPublicKey().toString('hex')).toBe('02486553b276cfe7abf0efbcd8d173e55db9c03da020c33d0b219df24124da18ee');
 
@@ -34,7 +84,7 @@ describe('PlatformKeyPair', () => {
   });
 
   test('repeatable 3', () => {
-    const kp:PlatformKeyPair = new PlatformKeyPair(hrp, alias);
+    const kp:PlatformVMKeyPair = new PlatformVMKeyPair(hrp, alias);
     kp.importKey(Buffer.from('d0e17d4b31380f96a42b3e9ffc4c1b2a93589a1e51d86d7edc107f602fbc7475', 'hex'));
     expect(kp.getPublicKey().toString('hex')).toBe('031475b91d4fcf52979f1cf107f058088cc2bea6edd51915790f27185a7586e2f2');
 
@@ -47,7 +97,7 @@ describe('PlatformKeyPair', () => {
   });
 
   test('Creation Empty', () => {
-    const kp:PlatformKeyPair = new PlatformKeyPair(hrp, alias);
+    const kp:PlatformVMKeyPair = new PlatformVMKeyPair(hrp, alias);
     expect(kp.getPrivateKey()).not.toBeUndefined();
     expect(kp.getAddress()).not.toBeUndefined();
     expect(kp.getPrivateKeyString()).not.toBeUndefined();
@@ -62,13 +112,13 @@ describe('PlatformKeyPair', () => {
   });
 });
 
-describe('PlatformKeyChain', () => {
+describe('PlatformVMKeyChain', () => {
   test('importKey from Buffer', () => {
     const keybuff:Buffer = Buffer.from('d0e17d4b31380f96a42b3e9ffc4c1b2a93589a1e51d86d7edc107f602fbc7475', 'hex');
-    const kc:PlatformKeyChain = new PlatformKeyChain(hrp, alias);
-    const kp2:PlatformKeyPair = new PlatformKeyPair(hrp, alias);
+    const kc:PlatformVMKeyChain = new PlatformVMKeyChain(hrp, alias);
+    const kp2:PlatformVMKeyPair = new PlatformVMKeyPair(hrp, alias);
     const addr1:Buffer = kc.importKey(keybuff);
-    const kp1:PlatformKeyPair = kc.getKey(addr1);
+    const kp1:PlatformVMKeyPair = kc.getKey(addr1);
     kp2.importKey(keybuff);
     const addr2 = kp1.getAddress();
     expect(addr1.toString('hex')).toBe(addr2.toString('hex'));
@@ -79,10 +129,10 @@ describe('PlatformKeyChain', () => {
 
   test('importKey from serialized string', () => {
     const keybuff:Buffer = Buffer.from('d0e17d4b31380f96a42b3e9ffc4c1b2a93589a1e51d86d7edc107f602fbc7475', 'hex');
-    const kc:PlatformKeyChain = new PlatformKeyChain(hrp, alias);
-    const kp2:PlatformKeyPair = new PlatformKeyPair(hrp, alias);
+    const kc:PlatformVMKeyChain = new PlatformVMKeyChain(hrp, alias);
+    const kp2:PlatformVMKeyPair = new PlatformVMKeyPair(hrp, alias);
     const addr1:Buffer = kc.importKey("PrivateKey-" + bintools.cb58Encode(keybuff));
-    const kp1:PlatformKeyPair = kc.getKey(addr1);
+    const kp1:PlatformVMKeyPair = kc.getKey(addr1);
     kp2.importKey(keybuff);
     const addr2 = kp1.getAddress();
     expect(addr1.toString('hex')).toBe(addr2.toString('hex'));
@@ -93,8 +143,8 @@ describe('PlatformKeyChain', () => {
 
   test('removeKey via keypair', () => {
     const keybuff:Buffer = Buffer.from('d0e17d4b31380f96a42b3e9ffc4c1b2a93589a1e51d86d7edc107f602fbc7475', 'hex');
-    const kc:PlatformKeyChain = new PlatformKeyChain(hrp, alias);
-    const kp1:PlatformKeyPair = new PlatformKeyPair(hrp, alias);
+    const kc:PlatformVMKeyChain = new PlatformVMKeyChain(hrp, alias);
+    const kp1:PlatformVMKeyPair = new PlatformVMKeyPair(hrp, alias);
     const addr1:Buffer = kc.importKey(keybuff);
     kp1.importKey(keybuff);
     expect(kc.hasKey(addr1)).toBe(true);
@@ -104,7 +154,7 @@ describe('PlatformKeyChain', () => {
 
   test('removeKey via string', () => {
     const keybuff:Buffer = Buffer.from('d0e17d4b31380f96a42b3e9ffc4c1b2a93589a1e51d86d7edc107f602fbc7475', 'hex');
-    const kc:PlatformKeyChain = new PlatformKeyChain(hrp, alias);
+    const kc:PlatformVMKeyChain = new PlatformVMKeyChain(hrp, alias);
     const addr1:Buffer = kc.importKey(keybuff);
     expect(kc.hasKey(addr1)).toBe(true);
     kc.removeKey(addr1);
@@ -113,7 +163,7 @@ describe('PlatformKeyChain', () => {
 
   test('removeKey bad keys', () => {
     const keybuff:Buffer = Buffer.from('d0e17d4b31380f96a42b3e9ffc4c1b2a93589a1e51d86d7edc107f602fbc7475', 'hex');
-    const kc:PlatformKeyChain = new PlatformKeyChain(hrp, alias);
+    const kc:PlatformVMKeyChain = new PlatformVMKeyChain(hrp, alias);
     const addr1:Buffer = kc.importKey(keybuff);
     expect(kc.hasKey(addr1)).toBe(true);
     expect(kc.removeKey(bintools.cb58Decode('6Y3kysjF9jnHnYkdS9yGAuoHyae2eNmeV'))).toBe(false);

--- a/tests/apis/platformvm/keychain.test.ts
+++ b/tests/apis/platformvm/keychain.test.ts
@@ -1,5 +1,5 @@
 import { PlatformVMKeyChain, PlatformVMKeyPair } from 'src/apis/platformvm/keychain';
-import { Avalanche } from './../../../src/index'
+import { Avalanche } from 'src/index'
 import { Buffer } from 'buffer/';
 import createHash from 'create-hash';
 import BinTools from 'src/utils/bintools';
@@ -16,43 +16,43 @@ describe('PlatformVMKeyPair', () => {
 
   test('human readable part', () => {
     let hrp:string = avalanche.getHRP();
-    let networkID:number = avalanche.getNetworkID()
+    let networkID:number = avalanche.getNetworkID();
     expect(hrp).toBe("local");
     expect(networkID).toBe(12345);
 
     avalanche.setNetworkID(2);
     hrp = avalanche.getHRP();
-    networkID = avalanche.getNetworkID()
+    networkID = avalanche.getNetworkID();
     expect(hrp).toBe("cascade");
     expect(networkID).toBe(2);
 
     avalanche.setNetworkID(3);
     hrp = avalanche.getHRP();
-    networkID = avalanche.getNetworkID()
+    networkID = avalanche.getNetworkID();
     expect(hrp).toBe("denali");
     expect(networkID).toBe(3);
 
     avalanche.setNetworkID(4);
     hrp = avalanche.getHRP();
-    networkID = avalanche.getNetworkID()
+    networkID = avalanche.getNetworkID();
     expect(hrp).toBe("everest");
     expect(networkID).toBe(4);
 
     avalanche.setNetworkID(0);
     hrp = avalanche.getHRP();
-    networkID = avalanche.getNetworkID()
+    networkID = avalanche.getNetworkID();
     expect(hrp).toBe("custom");
     expect(networkID).toBe(0);
 
     avalanche.setNetworkID(1);
     hrp = avalanche.getHRP();
-    networkID = avalanche.getNetworkID()
+    networkID = avalanche.getNetworkID();
     expect(hrp).toBe("avax");
     expect(networkID).toBe(1);
 
     avalanche.setNetworkID(12345);
     hrp = avalanche.getHRP();
-    networkID = avalanche.getNetworkID()
+    networkID = avalanche.getNetworkID();
     expect(hrp).toBe("local");
     expect(networkID).toBe(12345);
   });

--- a/tests/avalanche.test.ts
+++ b/tests/avalanche.test.ts
@@ -51,8 +51,8 @@ describe('Avalanche', () => {
         expect(avalanche.Info()).not.toBeInstanceOf(KeystoreAPI);
         expect(avalanche.Info()).toBeInstanceOf(InfoAPI);
         
-        expect(avalanche.Platform()).not.toBeInstanceOf(KeystoreAPI);
-        expect(avalanche.Platform()).toBeInstanceOf(PlatformVMAPI);
+        expect(avalanche.PlatformVM()).not.toBeInstanceOf(KeystoreAPI);
+        expect(avalanche.PlatformVM()).toBeInstanceOf(PlatformVMAPI);
 
         expect(avalanche.NodeKeys()).not.toBeInstanceOf(PlatformVMAPI);
         expect(avalanche.NodeKeys()).toBeInstanceOf(KeystoreAPI);
@@ -62,7 +62,7 @@ describe('Avalanche', () => {
 
         expect(avalanche.Admin().getRPCID()).toBe(1);
         expect(avalanche.AVM().getRPCID()).toBe(1);
-        expect(avalanche.Platform().getRPCID()).toBe(1);
+        expect(avalanche.PlatformVM().getRPCID()).toBe(1);
         expect(avalanche.NodeKeys().getRPCID()).toBe(1);
     });
 


### PR DESCRIPTION
* export `PlatformVMConstants`
* Rename `PlatformKeyPair` to `PlatformVMKeyPair`
* Rename `PlatformKeyChain` to `PlatformVMKeyChain`
* Test human readable part of `AVMKeyPair` and `PlatformVMKeyPair`
* Update `platform` paths to `platformvm`
* Remove trailing `1`
* Remove dead code