### PR TITLE
Change response type for MetricsAPI

### DIFF
--- a/src/apis/metrics/api.ts
+++ b/src/apis/metrics/api.ts
@@ -23,22 +23,7 @@ export class MetricsAPI extends RESTAPI {
     };
 
   }
-  post = async (method:string, params?:Array<object> | object, baseurl?:string,
-    contentType?:string, acceptType?:string):Promise<RequestResponseData> => {
-    const ep:string = baseurl || this.baseurl;
-    const rpc:any = {};
-    rpc.method = method;
 
-    // Set parameters if exists
-    if (params) {
-      rpc.params = params;
-    }
-
-    const headers:object = this.prepHeaders(contentType, acceptType);
-
-    return this.core.post(ep, {}, JSON.stringify(rpc), headers, this.axConf())
-      .then((resp:RequestResponseData) => resp);
-  };
   /**
      *
      * @returns Promise for an object containing the metrics response

--- a/src/apis/metrics/api.ts
+++ b/src/apis/metrics/api.ts
@@ -5,6 +5,7 @@
 import AvalancheCore from '../../avalanche';
 import { RESTAPI } from '../../common/restapi';
 import { RequestResponseData } from '../../common/apibase';
+import { AxiosRequestConfig } from 'axios';
 
 
 /**
@@ -15,6 +16,29 @@ import { RequestResponseData } from '../../common/apibase';
  * @remarks This extends the [[RESTAPI]] class. This class should not be directly called. Instead, use the [[Avalanche.addAPI]] function to register this interface with Avalanche.
  */
 export class MetricsAPI extends RESTAPI {
+  protected axConf = ():AxiosRequestConfig => {
+    return  {
+      baseURL: `${this.core.getProtocol()}://${this.core.getIP()}:${this.core.getPort()}`,
+      responseType: 'text',
+    };
+
+  }
+  post = async (method:string, params?:Array<object> | object, baseurl?:string,
+    contentType?:string, acceptType?:string):Promise<RequestResponseData> => {
+    const ep:string = baseurl || this.baseurl;
+    const rpc:any = {};
+    rpc.method = method;
+
+    // Set parameters if exists
+    if (params) {
+      rpc.params = params;
+    }
+
+    const headers:object = this.prepHeaders(contentType, acceptType);
+
+    return this.core.post(ep, {}, JSON.stringify(rpc), headers, this.axConf())
+      .then((resp:RequestResponseData) => resp);
+  };
   /**
      *
      * @returns Promise for an object containing the metrics response


### PR DESCRIPTION
Per https://github.com/ava-labs/avalanche.js/issues/54 override `axCon` in `MetricsAPI` to set `responseType` to `'text'`.