### PR TITLE
Introduce travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+
+node_js:
+  - 12.13.1
+
+before_install:
+  - npm install
+
+script:
+  - npm run test


### PR DESCRIPTION
This PR introduces automatic travis builds to avalanchejs.

Currently it just runs `npm install` and then `npm run test`